### PR TITLE
Update size and fix instance of empty list.

### DIFF
--- a/utility/palm.py
+++ b/utility/palm.py
@@ -103,6 +103,9 @@ def gpt_job_analyze(list_of_opps: List[Opportunity], prompt: str) -> List[Opport
     for _ in range(MAX_RETRY):  # Keep looping until a valid prompt is received
         try:
             parsed_values = get_parsed_values(prompt)
+
+            if len(parsed_values) == 0:
+                continue
             break
         except (
             json.decoder.JSONDecodeError

--- a/utility/scrape.py
+++ b/utility/scrape.py
@@ -11,7 +11,7 @@ from time import sleep
 load_dotenv()
 utils.verify_set_env_variables()
 
-MAX_OPPORTUNITY_LIST_LENGTH = 15
+MAX_OPPORTUNITY_LIST_LENGTH = 10
 
 # ----------------- INTERNSHIP DATA -----------------
 


### PR DESCRIPTION
PaLM can return empty list, if that's the case retry to the next iteration. This can be the case of large input - PaLM can't read alot of data at the same time (rip bozo L).